### PR TITLE
Use map_to_world to get global cell positions

### DIFF
--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -164,7 +164,7 @@ func get_used_cell_global_positions():
 	var cells = get_used_cells()
 	var cell_positions = []
 	for cell in cells:
-		var cell_position = global_position + cell*cell_size
+		var cell_position = global_position + map_to_world(cell)
 		cell_positions.append(cell_position)
 	return cell_positions
 


### PR DESCRIPTION
# Description
Use `map_to_world` to compute the global cell positions.

# Reason
The current formula would only work when using square TileMap. The `map_to_world` would properly transform any cell positions to world coordinates.