### PR TITLE
Use NodePath for debugging the board

### DIFF
--- a/AstarDebug.gd
+++ b/AstarDebug.gd
@@ -1,12 +1,7 @@
 extends Control
 
-var astar
-var board setget set_board
-
-func set_board(value):
-	board = value
-	if board is AstarTileMap:
-		astar = board.astar
+export(NodePath) onready var board = get_node(board)
+onready var astar = board.astar if board else null
 
 func _physics_process(delta):
 	update()

--- a/World.gd
+++ b/World.gd
@@ -5,9 +5,6 @@ onready var astarDebug = $AstarDebug
 onready var player = $Board/Player
 onready var line = $Line
 
-func _ready():
-	astarDebug.board = board
-
 func _input(event):
 	if event.is_action_pressed("mouse_left"):
 		var target_cell = (event.position / board.cell_size).floor() * board.cell_size

--- a/World.tscn
+++ b/World.tscn
@@ -75,6 +75,7 @@ position = Vector2( 320, 256 )
 margin_right = 64.0
 margin_bottom = 64.0
 script = ExtResource( 6 )
+board = NodePath("../Board")
 
 [node name="Line" type="Line2D" parent="."]
 width = 8.0


### PR DESCRIPTION
# Description
Use `export` to expose `NodePath` to the board.

# Reason
This allows connecting the board from the editor instead of needing to write code.