### PR TITLE
Allow negative numbers for cantor pairing

### DIFF
--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -2,6 +2,7 @@ extends TileMap
 class_name AstarTileMap
 
 const DIRECTIONS := [Vector2.RIGHT, Vector2.UP, Vector2.LEFT, Vector2.DOWN]
+const CANTOR_LIMIT = int(pow(2, 31))
 
 var astar := AStar2D.new()
 var obstacles := []
@@ -149,11 +150,16 @@ func path_directions(path) -> Array:
 		directions.append(path[p] - path[p - 1])
 	return directions
 
+func to_natural(num: int) -> int:
+	if num < 0:
+		return CANTOR_LIMIT + num
+	return num
+
 func get_point(point_position: Vector2) -> int:
 	# Cantor pairing function
-	var a := int(point_position.x)
-	var b := int(point_position.y)
-	return (a + b) * (a + b + 1) / 2 + b
+	var a := to_natural(point_position.x)
+	var b := to_natural(point_position.y)
+	return (a + b + 1) / 2 * (a + b) + b
 
 func has_point(point_position: Vector2) -> bool:
 	var point_id := get_point(point_position)


### PR DESCRIPTION
Cantor pairing only works for natural numbers. `TileMap` allows cells to have negative indices. This can actually break the existing logic. In the cantor pairing function we need to translate negative numbers to natural numbers. I chose to use similar overflow behavior you would find when wrapping an unsigned integer. When a number comes in that is negative like `-1` it gets translated to `9223372030412324865` and decreases from there.

I had to switch around order of operations in the math to divide earlier and prevent integer overflow. I spent a while debugging an issue related to this so hopefully this saves someone some effort.