### PR TITLE
Fix duplicate values for cantor pairing

### DIFF
--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -2,7 +2,7 @@ extends TileMap
 class_name AstarTileMap
 
 const DIRECTIONS := [Vector2.RIGHT, Vector2.UP, Vector2.LEFT, Vector2.DOWN]
-const CANTOR_LIMIT = int(pow(2, 31))
+const CANTOR_LIMIT = int(pow(2, 30))
 
 var astar := AStar2D.new()
 var obstacles := []
@@ -159,7 +159,7 @@ func get_point(point_position: Vector2) -> int:
 	# Cantor pairing function
 	var a := to_natural(point_position.x)
 	var b := to_natural(point_position.y)
-	return (a + b + 1) / 2 * (a + b) + b
+	return (a + b) * (a + b + 1) / 2 + b
 
 func has_point(point_position: Vector2) -> bool:
 	var point_id := get_point(point_position)


### PR DESCRIPTION
Looks like dividing by 2 too early was not a great idea. I found out the hard way that duplicates can still occur due to integer division.
Decreasing the limit further by a factor of 2 to prevent overflow.
2^30 still gives plenty of space to work with in the grid too, no need to be limit testing or fancy.

Example:
(2,0) = (2+0+1)/2 * (2+0) + 0 = 3/2 * 2 = 1 * 2 = 2
(0,1) = (0+1+1)/2 * (0+1) + 1 = 2/2 * 1 + 1 = 1*1 + 1 = 2

I wrote a test to check for duplicates
```gd
for y in range(-20, 20):
  for x in range(-20, 20):
    var point := Vector2(x, y)
    prints(point, id(point))
```

And found no duplicates after the above change