### PR TITLE
Do not infer data type from null where Vector2 should be.

### DIFF
--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -45,13 +45,13 @@ func add_unit(unit: Object) -> void:
 func remove_unit(unit: Object) -> void:
 	units.erase(unit)
 
-func position_has_obstacle(obstacle_position: Vector2, ignore_obstacle_position := null) -> bool:
+func position_has_obstacle(obstacle_position: Vector2, ignore_obstacle_position = null) -> bool:
 	if obstacle_position == ignore_obstacle_position: return false
 	for obstacle in obstacles:
 		if obstacle.global_position == obstacle_position: return true
 	return false
 
-func position_has_unit(unit_position: Vector2, ignore_unit_position := null) -> bool:
+func position_has_unit(unit_position: Vector2, ignore_unit_position = null) -> bool:
 	if unit_position == ignore_unit_position: return false
 	for unit in units:
 		if unit.global_position == unit_position: return true


### PR DESCRIPTION
Functions position_has_obstacle and position_has_unit have second value to ignore specified position.

This is used for example in situation where you floodfill skiping units, but you still want to be able to show reachable tiles when clicking on unit having it as first node in search.

Position is defined as Vector2, but in function there is a default defined as:
ignore_unit_position := null
:= infers data type - which in Godot is IMHO null

Simple change of := to = should address the issue.