### PR TITLE
Add option to choose pairing method (via Board variable)

### DIFF
--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -192,7 +192,7 @@ func cantor_pair_signed(a:int, b:int) -> int:
 		b = (b * -2) - 1
 	return cantor_pair(a, b)
 
-func szudzik_pair(a:int ,b:int) -> int:
+func szudzik_pair(a:int, b:int) -> int:
 	if a >= b: 
 		return (a * a) + a + b
 	else: 


### PR DESCRIPTION
I've added an option to choose the pairing method (Cantor and Szudzik). 
If the user doesn't have to use negative values, then unsigned methods will be a better option. 
New signed method should work with negative values.