### PR TITLE
Fix szudzik-signed method not working properly

### DIFF
--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -207,7 +207,7 @@ func szudzik_pair_signed(a: int, b: int) -> int:
 		b = b * 2
 	else: 
 		b = (b * -2) - 1
-	return int((szudzik_pair(a, b) * 0.5))
+	return int(szudzik_pair(a, b))
 
 func szudzik_pair_improved(x:int, y:int) -> int:
 	var a: int
@@ -220,7 +220,7 @@ func szudzik_pair_improved(x:int, y:int) -> int:
 		b = y * 2
 	else: 
 		b = (y * -2) - 1	
-	var c = szudzik_pair(a,b) * 0.5
+	var c = szudzik_pair(a,b)
 	if a >= 0 and b < 0 or b >= 0 and a < 0:
 		return -c - 1
 	return c


### PR DESCRIPTION
I was testing Szudzik's signed method #15 with negative numbers. There were some points missing from the Astar grid.

I've examined other implementations of szudzik's pairing method and have found a solution.

## Before:
<img src="https://user-images.githubusercontent.com/31369647/195852507-86ae632a-a562-4129-9d4f-68f249081d98.png" alt="drawing" width="600"/>

## After
<img src="https://user-images.githubusercontent.com/31369647/195852510-f36ea2ac-c297-4b12-add7-863c4c08845c.png" alt="drawing" width="600"/>
