### PR TITLE
Make compatible with Godot 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+.godot

--- a/AstarDebug.gd
+++ b/AstarDebug.gd
@@ -1,7 +1,7 @@
 extends Control
 
 @export var board: AstarTileMap
-@onready var astar = board.astar if board else null
+@onready var astar: AStar2D = board.astar if board else null
 
 
 func position_has_obstacle(obstacle_position):
@@ -9,8 +9,8 @@ func position_has_obstacle(obstacle_position):
 
 func _draw():
 	if not astar is AStar2D: return
-	var offset = board.cell_size/2
-	for point in astar.get_points():
+	var offset = Vector2.ZERO # Vector2( board.tile_set.tile_size )/2
+	for point in astar.get_point_ids():
 		if astar.is_point_disabled(point): continue
 		var point_position = astar.get_point_position(point)
 		if position_has_obstacle(point_position): continue

--- a/AstarDebug.gd
+++ b/AstarDebug.gd
@@ -1,7 +1,7 @@
 extends Control
 
-export(NodePath) onready var board = get_node(board)
-onready var astar = board.astar if board else null
+@export var board: AstarTileMap
+@onready var astar = board.astar if board else null
 
 
 func position_has_obstacle(obstacle_position):
@@ -15,7 +15,7 @@ func _draw():
 		var point_position = astar.get_point_position(point)
 		if position_has_obstacle(point_position): continue
 		
-		draw_circle(point_position+offset, 4, Color.white)
+		draw_circle(point_position+offset, 4, Color.WHITE)
 		
 		var point_connections = astar.get_point_connections(point)
 		var connected_positions = []
@@ -26,4 +26,4 @@ func _draw():
 			connected_positions.append(connected_point_position)
 			
 		for connected_position in connected_positions:
-			draw_line(point_position+offset, connected_position+offset, Color.white, 2)
+			draw_line(point_position+offset, connected_position+offset, Color.WHITE, 2)

--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -260,7 +260,7 @@ func connect_cardinals(point_position) -> void:
 		directions += diagonals_array
 	
 	for direction in directions:
-		var cardinal_point := get_point(point_position + map_to_local(direction))
+		var cardinal_point := get_point(point_position + direction * tile_set.tile_size.x  )
 		if cardinal_point != center and astar.has_point(cardinal_point):
 			astar.connect_points(center, cardinal_point, true)
 

--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -9,6 +9,7 @@ enum pairing_methods {
 	SZUDZIK_UNSIGNED,	# more efficient than cantor
 	SZUDZIK_SIGNED,		# both positive and negative values
 	SZUDZIK_IMPROVED,	# improved version (best option)
+	SHIFTY_PAIR # For debugging; x and y are seeable by human. Ish.
 }
 
 @export var current_pairing_method : pairing_methods = pairing_methods.SZUDZIK_IMPROVED
@@ -136,7 +137,7 @@ func get_floodfill_positions(start_position: Vector2, min_range: int, max_range:
 		floodfill_positions.append(current_position)
 
 		for direction in DIRECTIONS:
-			var new_position := current_position + self.map_to_local(direction)
+			var new_position := current_position + self.global_position + self.map_to_local(direction)
 			if skip_obstacles and position_has_obstacle(new_position): continue
 			if skip_units and position_has_unit(new_position): continue
 			if new_position in floodfill_positions: continue
@@ -167,8 +168,8 @@ func path_directions(path) -> Array:
 	return directions
 
 func get_point(point_position: Vector2) -> int:
-	var a := int(point_position.x)
-	var b := int(point_position.y)
+	var a := int(point_position.x / self.tile_set.tile_size.x)
+	var b := int(point_position.y / self.tile_set.tile_size.y)
 	match current_pairing_method:
 		pairing_methods.CANTOR_UNSIGNED:
 			assert(a >= 0 and b >= 0, "Board: pairing method has failed. Choose method that supports negative values.")
@@ -182,6 +183,8 @@ func get_point(point_position: Vector2) -> int:
 			return szudzik_pair_signed(a, b)
 		pairing_methods.SZUDZIK_IMPROVED:
 			return szudzik_pair_improved(a, b)
+		pairing_methods.SHIFTY_PAIR:
+			return shifty_pair(a, b)
 	return szudzik_pair_improved(a, b)
 
 func cantor_pair(a:int, b:int) -> int:
@@ -231,6 +234,10 @@ func szudzik_pair_improved(x:int, y:int) -> int:
 	if a >= 0 and b < 0 or b >= 0 and a < 0:
 		return -c - 1
 	return c
+
+func shifty_pair( x: int, y: int) -> int:
+	# Assume they are less than 1000, combine by shifting.
+	return x * 1000 + y
 
 func has_point(point_position: Vector2) -> bool:
 	var point_id := get_point(point_position)

--- a/AstarTileMap.gd
+++ b/AstarTileMap.gd
@@ -11,9 +11,12 @@ enum pairing_methods {
 	SZUDZIK_IMPROVED,	# improved version (best option)
 }
 
-export(pairing_methods) var current_pairing_method = pairing_methods.SZUDZIK_IMPROVED
+@export var current_pairing_method : pairing_methods = pairing_methods.SZUDZIK_IMPROVED
 
-export var diagonals := false
+@export var diagonals := false
+
+# The tile map layer to base the navigation on.
+var read_layer = 0
 
 var astar := AStar2D.new()
 var obstacles := []
@@ -40,19 +43,19 @@ func create_pathfinding_points() -> void:
 	for cell_position in used_cell_positions:
 		connect_cardinals(cell_position)
 
-func add_obstacle(obstacle: Object) -> void:
+func add_obstacle(obstacle: Node) -> void:
 	obstacles.append(obstacle)
-	if not obstacle.is_connected("tree_exiting", self, "remove_obstacle"):
-		var _error := obstacle.connect("tree_exiting", self, "remove_obstacle", [obstacle])
+	if not obstacle.tree_exiting.is_connected(self.remove_obstacle):
+		var _error := obstacle.tree_exiting.connect( self.remove_obstacle.bind( obstacle ) )
 		if _error != 0: push_error(str(obstacle) + ": failed connect() function")
 
 func remove_obstacle(obstacle: Object) -> void:
 	obstacles.erase(obstacle)
 
-func add_unit(unit: Object) -> void:
+func add_unit(unit: Node) -> void:
 	units.append(unit)
-	if not unit.is_connected("tree_exiting", self, "remove_unit"):
-		var _error := unit.connect("tree_exiting", self, "remove_unit", [unit])
+	if not unit.tree_exiting.is_connected(self.remove_unit):
+		var _error := unit.tree_exiting.connect(self.remove_unit.bind(unit))
 		if _error != 0: push_error(str(unit) + ": failed connect() function")
 
 func remove_unit(unit: Object) -> void:
@@ -116,7 +119,7 @@ func get_floodfill_positions(start_position: Vector2, min_range: int, max_range:
 	var floodfill_positions := []
 	var checking_positions := [start_position]
 
-	while not checking_positions.empty():
+	while not checking_positions.is_empty():
 		var current_position : Vector2 = checking_positions.pop_back()
 		if skip_obstacles and position_has_obstacle(current_position, start_position): continue
 		if skip_units and position_has_unit(current_position, start_position): continue
@@ -133,7 +136,7 @@ func get_floodfill_positions(start_position: Vector2, min_range: int, max_range:
 		floodfill_positions.append(current_position)
 
 		for direction in DIRECTIONS:
-			var new_position := current_position + map_to_world(direction)
+			var new_position := current_position + self.map_to_local(direction)
 			if skip_obstacles and position_has_obstacle(new_position): continue
 			if skip_units and position_has_unit(new_position): continue
 			if new_position in floodfill_positions: continue
@@ -234,10 +237,10 @@ func has_point(point_position: Vector2) -> bool:
 	return astar.has_point(point_id)
 
 func get_used_cell_global_positions() -> Array:
-	var cells = get_used_cells()
+	var cells = get_used_cells( self.read_layer )
 	var cell_positions := []
 	for cell in cells:
-		var cell_position := global_position + map_to_world(cell)
+		var cell_position := global_position + map_to_local(cell)
 		cell_positions.append(cell_position)
 	return cell_positions
 
@@ -250,10 +253,10 @@ func connect_cardinals(point_position) -> void:
 		directions += diagonals_array
 	
 	for direction in directions:
-		var cardinal_point := get_point(point_position + map_to_world(direction))
+		var cardinal_point := get_point(point_position + map_to_local(direction))
 		if cardinal_point != center and astar.has_point(cardinal_point):
 			astar.connect_points(center, cardinal_point, true)
 
 func get_grid_distance(distance: Vector2) -> float:
-	var vec := world_to_map(distance).abs().floor()
+	var vec := local_to_map(distance).abs()
 	return vec.x + vec.y

--- a/D6.png.import
+++ b/D6.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/D6.png-6c575faccc49ff17e8f14be59da3fd95.stex"
+type="CompressedTexture2D"
+uid="uid://cjq5g36vd2eyd"
+path="res://.godot/imported/D6.png-6c575faccc49ff17e8f14be59da3fd95.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,24 @@ metadata={
 [deps]
 
 source_file="res://D6.png"
-dest_files=[ "res://.import/D6.png-6c575faccc49ff17e8f14be59da3fd95.stex" ]
+dest_files=["res://.godot/imported/D6.png-6c575faccc49ff17e8f14be59da3fd95.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/D6_outline.png.import
+++ b/D6_outline.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/D6_outline.png-3b4077c841a3714cd66785ea9e8e4670.stex"
+type="CompressedTexture2D"
+uid="uid://470l4wyjhmig"
+path="res://.godot/imported/D6_outline.png-3b4077c841a3714cd66785ea9e8e4670.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,24 @@ metadata={
 [deps]
 
 source_file="res://D6_outline.png"
-dest_files=[ "res://.import/D6_outline.png-3b4077c841a3714cd66785ea9e8e4670.stex" ]
+dest_files=["res://.godot/imported/D6_outline.png-3b4077c841a3714cd66785ea9e8e4670.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/Pawn.png.import
+++ b/Pawn.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/Pawn.png-da0f362a1d182bb822ec23a0a67589a8.stex"
+type="CompressedTexture2D"
+uid="uid://cp7ffbyltj6km"
+path="res://.godot/imported/Pawn.png-da0f362a1d182bb822ec23a0a67589a8.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,24 @@ metadata={
 [deps]
 
 source_file="res://Pawn.png"
-dest_files=[ "res://.import/Pawn.png-da0f362a1d182bb822ec23a0a67589a8.stex" ]
+dest_files=["res://.godot/imported/Pawn.png-da0f362a1d182bb822ec23a0a67589a8.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/StructureWall.png.import
+++ b/StructureWall.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/StructureWall.png-77b9540f29c022041c1fe57947db39fd.stex"
+type="CompressedTexture2D"
+uid="uid://dkr8omenqt7rn"
+path="res://.godot/imported/StructureWall.png-77b9540f29c022041c1fe57947db39fd.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,24 @@ metadata={
 [deps]
 
 source_file="res://StructureWall.png"
-dest_files=[ "res://.import/StructureWall.png-77b9540f29c022041c1fe57947db39fd.stex" ]
+dest_files=["res://.godot/imported/StructureWall.png-77b9540f29c022041c1fe57947db39fd.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/World.gd
+++ b/World.gd
@@ -7,9 +7,9 @@ extends Node2D
 
 func _input(event):
 	if event.is_action_pressed("mouse_left"):
-		var target_cell = (event.position / board.tile_set.tile_size.x).floor() * board.tile_set.tile_size.x
+		var target_cell = event.position
 		var path_points = board.get_astar_path_avoiding_obstacles_and_units(player.global_position, target_cell)
-		line.position = board.tile_set.tile_size/2 # Use offset to move line to center of tiles
+		# line.position = board.tile_set.tile_size/2 # Use offset to move line to center of tiles
 		line.points = path_points
 	
 	if event.is_action_pressed("mouse_right"):

--- a/World.gd
+++ b/World.gd
@@ -1,15 +1,15 @@
 extends Node2D
 
-onready var board = $Board
-onready var astarDebug = $AstarDebug
-onready var player = $Board/Player
-onready var line = $Line
+@onready var board : AstarTileMap = $Board
+@onready var astarDebug = $AstarDebug
+@onready var player = $Board/Player
+@onready var line = $Line
 
 func _input(event):
 	if event.is_action_pressed("mouse_left"):
-		var target_cell = (event.position / board.cell_size).floor() * board.cell_size
+		var target_cell = (event.position / board.tile_set.tile_size.x).floor() * board.tile_set.tile_size.x
 		var path_points = board.get_astar_path_avoiding_obstacles_and_units(player.global_position, target_cell)
-		line.position = board.cell_size/2 # Use offset to move line to center of tiles
+		line.position = board.tile_set.tile_size/2 # Use offset to move line to center of tiles
 		line.points = path_points
 	
 	if event.is_action_pressed("mouse_right"):

--- a/World.tscn
+++ b/World.tscn
@@ -1,81 +1,93 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=3 uid="uid://cbhsef15v28rl"]
 
-[ext_resource path="res://D6.png" type="Texture" id=1]
-[ext_resource path="res://Wall.tscn" type="PackedScene" id=2]
-[ext_resource path="res://Player.tscn" type="PackedScene" id=3]
-[ext_resource path="res://World.gd" type="Script" id=4]
-[ext_resource path="res://AstarTileMap.gd" type="Script" id=5]
-[ext_resource path="res://AstarDebug.gd" type="Script" id=6]
+[ext_resource type="Texture2D" uid="uid://cjq5g36vd2eyd" path="res://D6.png" id="1"]
+[ext_resource type="PackedScene" path="res://Wall.tscn" id="2"]
+[ext_resource type="PackedScene" path="res://Player.tscn" id="3"]
+[ext_resource type="Script" path="res://World.gd" id="4"]
+[ext_resource type="Script" path="res://AstarTileMap.gd" id="5"]
+[ext_resource type="Script" path="res://AstarDebug.gd" id="6"]
 
-[sub_resource type="TileSet" id=1]
-0/name = "D6.png 0"
-0/texture = ExtResource( 1 )
-0/tex_offset = Vector2( 0, 0 )
-0/modulate = Color( 1, 1, 1, 1 )
-0/region = Rect2( 0, 0, 64, 64 )
-0/tile_mode = 0
-0/occluder_offset = Vector2( 0, 0 )
-0/navigation_offset = Vector2( 0, 0 )
-0/shape_offset = Vector2( 0, 0 )
-0/shape_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
-0/shape_one_way = false
-0/shape_one_way_margin = 0.0
-0/shapes = [  ]
-0/z_index = 0
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_srde2"]
+texture = ExtResource("1")
+texture_region_size = Vector2i(64, 64)
+0:0/next_alternative_id = 8
+0:0/0 = 0
+0:0/1 = 1
+0:0/1/flip_h = true
+0:0/2 = 2
+0:0/2/flip_v = true
+0:0/3 = 3
+0:0/3/flip_h = true
+0:0/3/flip_v = true
+0:0/4 = 4
+0:0/4/transpose = true
+0:0/5 = 5
+0:0/5/flip_h = true
+0:0/5/transpose = true
+0:0/6 = 6
+0:0/6/flip_v = true
+0:0/6/transpose = true
+0:0/7 = 7
+0:0/7/flip_h = true
+0:0/7/flip_v = true
+0:0/7/transpose = true
+
+[sub_resource type="TileSet" id="1"]
+tile_size = Vector2i(64, 64)
+sources/0 = SubResource("TileSetAtlasSource_srde2")
 
 [node name="World" type="Node2D"]
-script = ExtResource( 4 )
+script = ExtResource("4")
 
 [node name="Board" type="TileMap" parent="."]
-tile_set = SubResource( 1 )
-format = 1
-tile_data = PoolIntArray( 65539, 0, 0, 65540, 0, 0, 65541, 0, 0, 65542, 0, 0, 65543, 0, 0, 65544, 0, 0, 65547, 0, 0, 65548, 0, 0, 65549, 0, 0, 131074, 0, 0, 131075, 0, 0, 131076, 0, 0, 131077, 0, 0, 131078, 0, 0, 131079, 0, 0, 131080, 0, 0, 131083, 0, 0, 131085, 0, 0, 131086, 0, 0, 196610, 0, 0, 196611, 0, 0, 196612, 0, 0, 196613, 0, 0, 196614, 0, 0, 196615, 0, 0, 196616, 0, 0, 196619, 0, 0, 196620, 0, 0, 196621, 0, 0, 196622, 0, 0, 262146, 0, 0, 262147, 0, 0, 262148, 0, 0, 262149, 0, 0, 262153, 0, 0, 262154, 0, 0, 262155, 0, 0, 262156, 0, 0, 262157, 0, 0, 327682, 0, 0, 327683, 0, 0, 327684, 0, 0, 327688, 0, 0, 327689, 0, 0, 327690, 0, 0, 327691, 0, 0, 327692, 0, 0, 327693, 0, 0, 393218, 0, 0, 393219, 0, 0, 393220, 0, 0, 393221, 0, 0, 393222, 0, 0, 393223, 0, 0, 393224, 0, 0, 393225, 0, 0, 393226, 0, 0, 393227, 0, 0, 393228, 0, 0, 393229, 0, 0, 458755, 0, 0, 458756, 0, 0, 458757, 0, 0, 458758, 0, 0, 458759, 0, 0, 458760, 0, 0, 458761, 0, 0, 458762, 0, 0, 458764, 0, 0, 458765, 0, 0, 458766, 0, 0, 524300, 0, 0, 524301, 0, 0, 524302, 0, 0 )
-script = ExtResource( 5 )
+tile_set = SubResource("1")
+format = 2
+layer_0/tile_data = PackedInt32Array(65539, 0, 0, 65540, 0, 0, 65541, 0, 0, 65542, 0, 0, 65543, 0, 0, 65544, 0, 0, 65547, 0, 0, 65548, 0, 0, 65549, 0, 0, 131074, 0, 0, 131075, 0, 0, 131076, 0, 0, 131077, 0, 0, 131078, 0, 0, 131079, 0, 0, 131080, 0, 0, 131083, 0, 0, 131085, 0, 0, 131086, 0, 0, 196610, 0, 0, 196611, 0, 0, 196612, 0, 0, 196613, 0, 0, 196614, 0, 0, 196615, 0, 0, 196616, 0, 0, 196619, 0, 0, 196620, 0, 0, 196621, 0, 0, 196622, 0, 0, 262146, 0, 0, 262147, 0, 0, 262148, 0, 0, 262149, 0, 0, 262153, 0, 0, 262154, 0, 0, 262155, 0, 0, 262156, 0, 0, 262157, 0, 0, 327682, 0, 0, 327683, 0, 0, 327684, 0, 0, 327688, 0, 0, 327689, 0, 0, 327690, 0, 0, 327691, 0, 0, 327692, 0, 0, 327693, 0, 0, 393218, 0, 0, 393219, 0, 0, 393220, 0, 0, 393221, 0, 0, 393222, 0, 0, 393223, 0, 0, 393224, 0, 0, 393225, 0, 0, 393226, 0, 0, 393227, 0, 0, 393228, 0, 0, 393229, 0, 0, 458755, 0, 0, 458756, 0, 0, 458757, 0, 0, 458758, 0, 0, 458759, 0, 0, 458760, 0, 0, 458761, 0, 0, 458762, 0, 0, 458764, 0, 0, 458765, 0, 0, 458766, 0, 0, 524300, 0, 0, 524301, 0, 0, 524302, 0, 0)
+script = ExtResource("5")
 
-[node name="Wall" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 256, 128 )
+[node name="Wall" parent="Board" instance=ExtResource("2")]
+position = Vector2(256, 128)
 
-[node name="Wall2" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 384, 128 )
+[node name="Wall2" parent="Board" instance=ExtResource("2")]
+position = Vector2(384, 128)
 
-[node name="Wall3" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 512, 192 )
+[node name="Wall3" parent="Board" instance=ExtResource("2")]
+position = Vector2(512, 192)
 
-[node name="Wall4" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 576, 384 )
+[node name="Wall4" parent="Board" instance=ExtResource("2")]
+position = Vector2(576, 384)
 
-[node name="Wall5" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 640, 384 )
+[node name="Wall5" parent="Board" instance=ExtResource("2")]
+position = Vector2(640, 384)
 
-[node name="Wall6" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 640, 320 )
+[node name="Wall6" parent="Board" instance=ExtResource("2")]
+position = Vector2(640, 320)
 
-[node name="Wall7" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 704, 320 )
+[node name="Wall7" parent="Board" instance=ExtResource("2")]
+position = Vector2(704, 320)
 
-[node name="Wall8" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 448, 448 )
+[node name="Wall8" parent="Board" instance=ExtResource("2")]
+position = Vector2(448, 448)
 
-[node name="Wall9" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 128, 320 )
+[node name="Wall9" parent="Board" instance=ExtResource("2")]
+position = Vector2(128, 320)
 
-[node name="Wall11" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 192, 320 )
+[node name="Wall11" parent="Board" instance=ExtResource("2")]
+position = Vector2(192, 320)
 
-[node name="Wall12" parent="Board" instance=ExtResource( 2 )]
-position = Vector2( 704, 128 )
+[node name="Wall12" parent="Board" instance=ExtResource("2")]
+position = Vector2(704, 128)
 
-[node name="Player" parent="Board" instance=ExtResource( 3 )]
-position = Vector2( 320, 256 )
+[node name="Player" parent="Board" instance=ExtResource("3")]
+position = Vector2(320, 256)
 
-[node name="Player2" parent="Board" instance=ExtResource( 3 )]
-position = Vector2( 320, 128 )
+[node name="Player2" parent="Board" instance=ExtResource("3")]
+position = Vector2(320, 128)
 
 [node name="AstarDebug" type="Control" parent="."]
-margin_right = 64.0
-margin_bottom = 64.0
-script = ExtResource( 6 )
-board = NodePath("../Board")
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("6")
 
 [node name="Line" type="Line2D" parent="."]
 width = 8.0

--- a/World.tscn
+++ b/World.tscn
@@ -84,10 +84,11 @@ position = Vector2(320, 256)
 [node name="Player2" parent="Board" instance=ExtResource("3")]
 position = Vector2(320, 128)
 
-[node name="AstarDebug" type="Control" parent="."]
+[node name="AstarDebug" type="Control" parent="." node_paths=PackedStringArray("board")]
 layout_mode = 3
 anchors_preset = 0
 script = ExtResource("6")
+board = NodePath("../Board")
 
 [node name="Line" type="Line2D" parent="."]
 width = 8.0

--- a/icon.png.import
+++ b/icon.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+type="CompressedTexture2D"
+uid="uid://din136q64n1cf"
+path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,24 @@ metadata={
 [deps]
 
 source_file="res://icon.png"
-dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/project.godot
+++ b/project.godot
@@ -6,35 +6,30 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
-
-_global_script_classes=[ {
-"base": "TileMap",
-"class": "AstarTileMap",
-"language": "GDScript",
-"path": "res://AstarTileMap.gd"
-} ]
-_global_script_class_icons={
-"AstarTileMap": ""
-}
+config_version=5
 
 [application]
 
 config/name="AstarTileMap"
 run/main_scene="res://World.tscn"
+config/features=PackedStringArray("4.1")
 config/icon="res://icon.png"
+
+[dotnet]
+
+project/assembly_name="AstarTileMap"
 
 [input]
 
 mouse_left={
 "deadzone": 0.5,
-"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
- ]
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
 }
 mouse_right={
 "deadzone": 0.5,
-"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":2,"pressed":false,"doubleclick":false,"script":null)
- ]
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
 }
 
 [physics]


### PR DESCRIPTION
This MR makes the script compatible with Godot 4. Be warned, in addition to the changes genuinely required, such as syntax changes, I ended up changing the tile indexing a bit. This is because I ran into weird problems, which I believe were caused by replacing `map_to_world`/`world_to_map` with `map_to_local` and `local_to_map`. The "world" versions are not available in Godot 4 and apparently the "local" versions don't behave exactly the same from the point of view of this script. I was able to get everything working again by removing some offsets and converting positions to grid coordinates before converting them to point IDs. It's probable that a smaller set of changes would have worked if I properly understood the difference between these function families and their usage here, but this works, and gives smaller id:s which I prefer anyways. Nonetheless, this MR may serve better as a reference if someone wishes to implement Godot 4 compatibility cleanly, than something to necessarily merge as-is.